### PR TITLE
applies Signature Dialog layout principles

### DIFF
--- a/HotTips/TipOfTheDayWindow.xaml
+++ b/HotTips/TipOfTheDayWindow.xaml
@@ -1,18 +1,22 @@
 ﻿<Window x:Class="HotTips.TipOfTheDayWindow"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             mc:Ignorable="d"
-             ResizeMode="CanResizeWithGrip"
-             WindowStartupLocation="CenterOwner"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mdxaml="clr-namespace:HotTips.Markdown.Xaml"
+        mc:Ignorable="d"
+        ResizeMode="CanResizeWithGrip"
+        WindowStartupLocation="CenterOwner"
+        WindowStyle="None"
+        ShowInTaskbar="False"
+        ShowActivated="True"
         Height="300"
         MinHeight="300"
         Width="450"
         MinWidth="450"
         PreviewKeyDown="Window_PreviewKeyDown"
-        >
+        MouseDown="Window_MouseDown"
+    >
     <Window.Resources>
 
         <Style x:Key="MyButton" TargetType="Button">
@@ -123,50 +127,69 @@
         <mdxaml:TextToFlowDocumentConverter x:Key="TextToFlowDocumentConverter" 
                                            Markdown="{StaticResource Markdown}"/>
     </Window.Resources>
-    <Border>
+    <Border BorderThickness="1" BorderBrush="Gray">
         <Grid>
-            <Label Content="Tip of the Day" HorizontalAlignment="Left" Margin="30,30,0,0" VerticalAlignment="Top" Height="36" FontSize="18" FontWeight="Bold"/>
-            <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,30, 30, 0" Height="36" Orientation="Horizontal">
-                <Label Content="Group:" HorizontalAlignment="Right" VerticalAlignment="Top" Height="36" />
-                <Label Name ="GroupNameLabel" Content="Group" HorizontalAlignment="Right" VerticalAlignment="Top" Height="36" />
-                <CheckBox Name="GroupNameCheckBox" IsChecked="True" HorizontalAlignment="Right" Margin="0,6,0,0" Height="36" VerticalAlignment="Top"
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="24"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="24"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="36"/>
+                <RowDefinition Height="auto"/> <!-- Title -->
+                <RowDefinition Height="24"/>
+                <RowDefinition Height="*"/> <!-- Main content -->
+                <RowDefinition Height="24"/>
+                <RowDefinition Height="23"/> <!-- Buttons -->
+                <RowDefinition Height="20"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Column="1" Grid.Row="1" Text="Tip of the Day" FontSize="28" FontFamily="Segoe UI Light" Padding="0 0 0 0" Foreground="#FF68217A" /> <!-- TODO: The text still has gap above the top of the letters -->
+
+            <DockPanel Grid.Column="1" Grid.Row="3">
+                <StackPanel DockPanel.Dock="Top" HorizontalAlignment="Right" VerticalAlignment="Bottom" Orientation="Horizontal">
+                    <Label Content="Group:" />
+                    <Label Name ="GroupNameLabel" Content="Group" />
+                    <CheckBox Name="GroupNameCheckBox" IsChecked="True"
                           ToolTip="Include tips from this group. (Uncheck to turn off)"
                           Unchecked="GroupNameCheckBox_Unchecked"
                           Checked="GroupNameCheckBox_Checked"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom">
+                    <Button Name="LikeButton" HorizontalAlignment="Right" ToolTip="Like" Width="20" Height="20" Style="{StaticResource MyButton}" BorderThickness="0" Click="LikeButton_Click"/>
+                    <Button Name="DislikeButton" HorizontalAlignment="Right" ToolTip="Dislike" Width="20" Height="20" Style="{StaticResource MyButton}" BorderThickness="0" Click="DislikeButton_Click"/>
+                </StackPanel>
+                <FlowDocumentScrollViewer Grid.Column="1" Grid.Row="3"  Name="TipContentViewer"
+                    VerticalAlignment="Top" MinWidth="400" MinHeight="160"
+                    Document="{Binding Path=TipContent, Converter={StaticResource TextToFlowDocumentConverter}}" 
+                />
+            </DockPanel>
+
+            <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="5" HorizontalAlignment="Right">
+                <Button Name="PrevTipButton"
+                        Content="&lt;&lt; _Previous"
+                        AutomationProperties.Name="Previous Tip"
+                        ToolTip="Show the previous tip"
+                        HorizontalAlignment="Left"
+                        Width="80"
+                        Click="PrevTipButton_Click"
+                        Margin="6 0 0 0"
+                        />
+                <Button Name="NextTipButton" Content="_Next Tip &gt;&gt;" Width="80" Click="NextTipButton_Click"
+                        AutomationProperties.Name="Next Tip"
+                        IsDefault="True" ToolTip="Show the next unseen tip"
+                        Margin="6 0 0 0"
+                        />
+                <Button Name="MoreLikeThisButton" Content="_More like this" Width="80"
+                        AutomationProperties.Name="More like this"
+                        ToolTip="Show a new tip from the same tip group" Click="MoreLikeThisButton_Click"
+                        Margin="6 0 0 0"
+                        />
+                <Button Name="CloseButton" Content="_Got it!" Width="80" 
+                        AutomationProperties.Name="Got it" ToolTip="Close Tip of the Day window"
+                        Click="CloseButton_Click" IsCancel="True"
+                        Margin="6 0 0 0"
+                        />
             </StackPanel>
-
-            <FlowDocumentScrollViewer Name="TipContentViewer"
-                Margin="30,60" VerticalAlignment="Top" MinWidth="400" MinHeight="160" Panel.ZIndex="5"
-                                  Document="{Binding Path=TipContent, Converter={StaticResource TextToFlowDocumentConverter}}" />
-
-            <Button Name="LikeButton" HorizontalAlignment="Right" Margin="50,40" ToolTip="Like" VerticalAlignment="Bottom" Width="20" Height="20" Style="{StaticResource MyButton}" BorderThickness="0" Click="LikeButton_Click"/>
-
-            <Button Name="DislikeButton" HorizontalAlignment="Right" Margin="25,40" ToolTip="Dislike" VerticalAlignment="Bottom" Width="20" Height="20" Style="{StaticResource MyButton}" BorderThickness="0" Click="DislikeButton_Click"/>
-            
-            <Button Name="PrevTipButton"
-                    Content="&lt;&lt; _Previous"
-                    AutomationProperties.Name="Previous Tip"
-                    ToolTip="Show the previous tip"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Bottom"
-                    Margin="30 10"
-                    Width="80"
-                    Click="PrevTipButton_Click"
-                    />
-            <Button Name="NextTipButton" Content="_Next Tip &gt;&gt;" HorizontalAlignment="Left" Margin="120 10"
-                    VerticalAlignment="Bottom" Width="80" Click="NextTipButton_Click"
-                    AutomationProperties.Name="Next Tip"
-                    IsDefault="True" ToolTip="Show the next unseen tip"
-                    />
-            <Button Name="MoreLikeThisButton" Content="_More like this" HorizontalAlignment="Left" Margin="210 0 0 10"
-                    VerticalAlignment="Bottom" Width="80"
-                    AutomationProperties.Name="More like this"
-                    ToolTip="Show a new tip from the same tip group" Click="MoreLikeThisButton_Click"
-                    />
-            <Button Name="CloseButton" Content="_Got it!" HorizontalAlignment="Right" Margin="10" VerticalAlignment="Bottom" Width="75"
-                    AutomationProperties.Name="Got it" ToolTip="Close Tip of the Day window"
-                    Click="CloseButton_Click" IsCancel="True"/>
-
         </Grid>
     </Border>
 </Window>

--- a/HotTips/TipOfTheDayWindow.xaml.cs
+++ b/HotTips/TipOfTheDayWindow.xaml.cs
@@ -332,6 +332,12 @@ namespace HotTips
             isLiked = true;
             isUnLiked = false;
         }
+
+        private void Window_MouseDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == System.Windows.Input.MouseButton.Left)
+                this.DragMove();
+        }
     }
 
 }


### PR DESCRIPTION
For now, these are initial changes. Don't merge this yet.
This addresses #25 

![image](https://user-images.githubusercontent.com/1673956/42956237-52c79bb4-8b34-11e8-8994-abda7a9460e8.png)

I'd like to get clarification on the "group" checkbox, thumbs up, thumbs down and "more like this" button. I think there is redundancy among these controls. How can we clean this up further?