### PR TITLE
Fix the tip group status on the options page

### DIFF
--- a/HotTips/Options/OptionsControl.xaml
+++ b/HotTips/Options/OptionsControl.xaml
@@ -7,7 +7,7 @@
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
     <Grid>
-        <GroupBox Header="Tip Groups" Margin="20" MinHeight="60" MaxHeight="400" VerticalAlignment="Top">
+        <GroupBox Header="Show tips from these groups" Margin="20" MinHeight="60" MaxHeight="400" VerticalAlignment="Top">
             <StackPanel x:Name="TipGroupsListBox" HorizontalAlignment="Left" MinHeight="60" Margin="20" VerticalAlignment="Top" CanVerticallyScroll="True"/>
         </GroupBox>
     </Grid>

--- a/HotTips/Options/OptionsControl.xaml.cs
+++ b/HotTips/Options/OptionsControl.xaml.cs
@@ -23,13 +23,28 @@ namespace HotTips.Options
         public OptionsControl()
         {
             InitializeComponent();
+
+            this.IsVisibleChanged += OptionsControl_IsVisibleChanged;
+        }
+
+        private void OptionsControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is bool visibility && visibility == true)
+            {
+                InitializeTipGroups();
+            }
         }
 
         internal CustomPage OptionsPage { get; set; }
 
         public void Initialize()
         {
+        }
+
+        private void InitializeTipGroups()
+        {
             var groups = GetTipGroups();
+            TipGroupsListBox.Children.Clear();
             foreach (var g in groups)
             {
                 var checkbox = new CheckBox()
@@ -43,7 +58,6 @@ namespace HotTips.Options
 
                 TipGroupsListBox.Children.Add(checkbox);
             }
-
         }
 
         private Dictionary<string, bool> GetTipGroups()
@@ -53,7 +67,7 @@ namespace HotTips.Options
             var tipGroupStatus = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var tipGroup in allTipGroups.Where(t => t != null).SelectMany(t => t))
             {
-                tipGroupStatus[tipGroup.groupId] = VSTipHistoryManager.Instance().IsTipGroupExcluded(tipGroup.groupId);
+                tipGroupStatus[tipGroup.groupId] = !VSTipHistoryManager.Instance().IsTipGroupExcluded(tipGroup.groupId);
             }
 
             return tipGroupStatus;


### PR DESCRIPTION
- The status is now refreshed every time the options page is shown.
- Changed the header text of the group box as below:
![image](https://user-images.githubusercontent.com/1521254/43108014-716458ce-8e94-11e8-9ced-05b60b0b92c7.png)
