### PR TITLE
Additional telemetry for tips

### DIFF
--- a/HotTips/Engine/VSTipHistoryManager.cs
+++ b/HotTips/Engine/VSTipHistoryManager.cs
@@ -220,5 +220,15 @@ namespace HotTips
             string value = string.Join(",", _excludedTipLevels.Select(l => l.ToString()));
             SettingsManager.SetValueAsync(EXCLUDED_TIP_LEVELS, value, isMachineLocal: !RoamSettings);
         }
+
+        public ISet<string> GetAllExcludedTipGroups()
+        {
+            return _excludedTipGroups;
+        }
+
+        public ISet<TipLevel> GetAllExcludedTipLevels()
+        {
+            return _excludedTipLevels;
+        }
     }
 }

--- a/HotTips/HotTips.csproj
+++ b/HotTips/HotTips.csproj
@@ -65,7 +65,8 @@
       <SubType>Component</SubType>
     </Compile>
     <Compile Include="SolutionEventHandler.cs" />
-    <Compile Include="TelemetryConstants.cs" />
+    <Compile Include="Telemetry\TelemetryConstants.cs" />
+    <Compile Include="Telemetry\TelemetryHelper.cs" />
     <Compile Include="TipOfTheDay.cs" />
     <Compile Include="TipViewModel.cs" />
     <Compile Include="Markdown.xaml\Markdown.cs" />

--- a/HotTips/Options/OptionsControl.xaml
+++ b/HotTips/Options/OptionsControl.xaml
@@ -6,7 +6,7 @@
              xmlns:local="clr-namespace:HotTips"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
-    <StackPanel Orientation="Vertical">
+    <StackPanel Orientation="Vertical" CanVerticallyScroll="True">
         <GroupBox Header="Show tips from these groups" Margin="10" VerticalAlignment="Top">
             <StackPanel x:Name="TipGroupsListBox" HorizontalAlignment="Left" MinHeight="60" Margin="20" VerticalAlignment="Top" CanVerticallyScroll="True"/>
         </GroupBox>

--- a/HotTips/Telemetry/TelemetryConstants.cs
+++ b/HotTips/Telemetry/TelemetryConstants.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace HotTips
+namespace HotTips.Telemetry
 {
     internal class TelemetryConstants
     {
         public const string TipEventPrefix = "Justcla/HotTips/";
         public const string TipShownEvent = TipEventPrefix + "TipShown";
+        public const string NextTipShown = TipEventPrefix + "NextTipShown";
+        public const string PrevTipShown = TipEventPrefix + "PrevTipShown";
         public const string TipLikedEvent = TipEventPrefix + "TipLiked";
         public const string TipLikeCanceledEvent = TipEventPrefix + "TipLikeCanceled";
         public const string TipDisLikedEvent = TipEventPrefix + "TipDisLiked";
@@ -17,5 +19,17 @@ namespace HotTips
         public const string TipGroupDisabled = TipEventPrefix + "TipGroupDisabled";
         public const string TipGroupEnabled = TipEventPrefix + "TipGroupEnabled";
         public const string MoreLikeThisTipClicked = TipEventPrefix + "MoreTipsSelected";
+        public const string DialogClosed = TipEventPrefix + "TipOfTheDayDialogClosed";
+
+        // Options page Events
+        public const string OptionsPageShown = TipEventPrefix + "TipOptionsPageShown";
+        public const string OptionsPageDismissed = TipEventPrefix + "TipOptionsPageDismissed";
+        public const string NextShowChanged = TipEventPrefix + "WhenToShowNextChanged";
+
+        public const string TipLevelEnabled = TipEventPrefix + "TipLevelEnabled";
+        public const string TipLevelDisabled = TipEventPrefix + "TipLevelDisabled";
+
+        public const string PackageLoad = TipEventPrefix + "HotTipsPackageLoad";
+
     }
 }

--- a/HotTips/Telemetry/TelemetryHelper.cs
+++ b/HotTips/Telemetry/TelemetryHelper.cs
@@ -1,0 +1,31 @@
+﻿using Justcla;
+using System.Linq;
+
+namespace HotTips.Telemetry
+{
+    internal static class TelemetryHelper
+    {
+        public static void LogTelemetryEvent(VSTipHistoryManager manager, string eventName, params object[] nameAndProperties)
+        {
+            var excludedGroups = manager.GetAllExcludedTipGroups();
+            var excludedTipLevels = manager.GetAllExcludedTipLevels();
+            var tipHistory = manager.GetTipHistory();
+
+            string excludedGroupStr = string.Join(";", excludedGroups);
+            string excludedLevelStr = string.Join(";", excludedTipLevels.Select(l => l.ToString()));
+            string tipHistoryStr = string.Join(";", tipHistory);
+
+            var properties = nameAndProperties.Concat(
+                new[]
+                {
+                    "ExcludedTipGroups", excludedGroupStr,
+                    "ExcludedTipLevels", excludedLevelStr,
+                    "TipHistory", tipHistoryStr
+                }).ToArray();
+
+            VSTelemetryHelper.PostEvent(eventName,
+                properties);
+        }
+
+    }
+}

--- a/HotTips/TipOfTheDayPackage.cs
+++ b/HotTips/TipOfTheDayPackage.cs
@@ -1,10 +1,12 @@
 ﻿using HotTips.Options;
+using Justcla;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.ComponentModel.Design;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Task = System.Threading.Tasks.Task;

--- a/HotTips/TipOfTheDayWindow.xaml.cs
+++ b/HotTips/TipOfTheDayWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Justcla;
+﻿using HotTips.Telemetry;
+using Justcla;
 using Microsoft.VisualStudio;
 using System;
 using System.Collections.Generic;
@@ -6,6 +7,7 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
@@ -64,6 +66,7 @@ namespace HotTips
 
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
+            LogTelemetryEvent(TelemetryConstants.DialogClosed);
             this.Close();
         }
 
@@ -71,12 +74,14 @@ namespace HotTips
         {
             GoToNextTip();
             PopulateDefaultImages();
+            LogTelemetryEvent(TelemetryConstants.NextTipShown);
         }
 
         private void PrevTipButton_Click(object sender, RoutedEventArgs e)
         {
             GoToPrevTip();
             PopulateDefaultImages();
+            LogTelemetryEvent(TelemetryConstants.PrevTipShown);
         }
 
         private void MoreLikeThisButton_Click(object sender, RoutedEventArgs e)
@@ -220,9 +225,6 @@ namespace HotTips
                 _tipHistoryManager.MarkTipAsSeen(currentTip);
             }
 
-            // Output telemetry: Tip Shown (Consider making this conditional on "markAsSeen")
-            LogTelemetryEvent(TelemetryConstants.TipShownEvent);
-
             return true;
         }
 
@@ -306,7 +308,10 @@ namespace HotTips
         private void LogTelemetryEvent(string eventName)
         {
             string tipGroupId = GroupNameLabel.Content.ToString();
-            VSTelemetryHelper.PostEvent(eventName, "TipGroupId", tipGroupId, "TipId", currentTip);
+
+            TelemetryHelper.LogTelemetryEvent(VSTipHistoryManager.GetInstance(), eventName,
+                "TipGroupId", tipGroupId,
+                "TipId", currentTip ?? string.Empty);
         }
 
         private void PopulateLikeImage()
@@ -354,6 +359,7 @@ namespace HotTips
         private void SettingsButton_Click(object sender, RoutedEventArgs e)
         {
             TipOfTheDayPackage.Instance.ShowOptionsPage();
+            LogTelemetryEvent(TelemetryConstants.OptionsPageShown);
         }
     }
 


### PR DESCRIPTION
- Adds telemetry events Next and previous buttons on TOTD dialog
- Adds telemetry events for Options page
- For every event, adds excluded tips levels, excluded groups and tip
history.